### PR TITLE
Add category to TOC 

### DIFF
--- a/ChocolateBar.toc
+++ b/ChocolateBar.toc
@@ -1,7 +1,7 @@
 ## Interface: @toc-version-retail@, @toc-version-midnight@
 #@debug@
 ## Interface: 120000
-#@end-debug@>
+#@end-debug@
 ## Interface-Retail: @toc-version-retail@
 ## Interface-Classic: @toc-version-classic@
 ## Interface-BCC: @toc-version-bcc@


### PR DESCRIPTION
I added the Data Broker category to the TOC; this makes it group up with other broker addons in the WoW addon list.

I debated whether this addon fit better in Data Broker or in User Interface, but ultimately I feel it would be better for broker displays to be listed alongside the brokers, not in a separate category.

The translations are taken from the suggested list of categories on the WoW wiki: https://warcraft.wiki.gg/wiki/Addon_Categories#Data_Broker
